### PR TITLE
Fix to pass CMAKE_GENERATOR because CMake's default is 32-bit

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 mkdir build
 cd build
 
-cmake -LAH ^
+cmake -LAH -G"%CMAKE_GENERATOR%" ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
     .. || goto :eof

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,11 +3,10 @@ cd build
 
 CMAKE_CONFIG="Release"
 
-cmake -LAH \
+cmake -LAH -G"$CMAKE_GENERATOR" \
   -DCMAKE_BUILD_TYPE=$CMAKE_CONFIG \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \
   -DCMAKE_PREFIX_PATH=$PREFIX \
   ..
 
 cmake --build . --config $CMAKE_CONFIG --target install
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 134c891b0b0f038d622554faa4040f6d419c534ed18c1b893f4f3ff788515d10
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -24,15 +24,29 @@ test:
     - cmake
     - {{ compiler('cxx') }}
     - make  # [unix]
+    - ninja
   files:
     - test
 
   commands:
+    - echo on  # [win]
     - cd test
-    - cmake . -DCMAKE_BUILD_TYPE=Release
+
+    - mkdir build_default
+    - cd build_default
+    - cmake .. -G"%CMAKE_GENERATOR%" -DCMAKE_BUILD_TYPE=Release  # [win]
+    - cmake .. -G"$CMAKE_GENERATOR" -DCMAKE_BUILD_TYPE=Release  # [unix]
     - cmake --build . --config Release
     - ./program  # [unix]
     - Release\\program.exe  # [win]
+    - cd ..
+
+    - mkdir build_ninja
+    - cd build_ninja
+    - cmake .. -G"Ninja" -DCMAKE_BUILD_TYPE=Release
+    - cmake --build . --config Release
+    - ./program  # [unix]
+    - program.exe  # [win]
 
 about:
   home: https://github.com/martinmoene/gsl-lite

--- a/recipe/test/main.cpp
+++ b/recipe/test/main.cpp
@@ -18,8 +18,8 @@ struct Widget
 
     void work() { non_owned_ptr = use( owned_ptr ); }
 
-    owner<int *> owned_ptr;	// if alias template support
-//  Owner(int *) owned_ptr;	// C++98 up
+//  owner<int *> owned_ptr;	// if alias template support
+    Owner(int *) owned_ptr;	// C++98 up
     int * non_owned_ptr;
 };
 


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* ~~[ ] Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* ~~[ ] Ensured the license file is being packaged.~~
